### PR TITLE
Refactor: Rename ReminderRepositoryDelegate to ...toryProtocol

### DIFF
--- a/quick-reminder/Model/ReminderList/ReminderList.swift
+++ b/quick-reminder/Model/ReminderList/ReminderList.swift
@@ -42,7 +42,7 @@ final class ReminderList: ReminderListProtocol {
     
     let notificationCenter = NotificationCenter()
     
-    private let repository: ReminderRepositoryDelegate!
+    private let repository: ReminderRepositoryProtocol!
     private let sorter: ReminderSorterProtocol!
     private let validator: ReminderListValidatorProtocol!
     
@@ -56,7 +56,7 @@ final class ReminderList: ReminderListProtocol {
     /// Reminderリストが空かを表すブール値。
     var isEmpty: Bool { reminders.isEmpty }
     
-    init(_ repository: ReminderRepositoryDelegate,
+    init(_ repository: ReminderRepositoryProtocol,
          _ sorter: ReminderSorterProtocol,
          _ validator: ReminderListValidatorProtocol) {
         self.repository = repository

--- a/quick-reminder/Model/Repository/ReminderRepository.swift
+++ b/quick-reminder/Model/Repository/ReminderRepository.swift
@@ -8,7 +8,7 @@
 import RealmSwift
 
 /// ReminderのCRUD操作のために、DBとやり取りを行うメソッド。
-protocol ReminderRepositoryDelegate {
+protocol ReminderRepositoryProtocol {
     func addReminder(_ reminder: Reminder)
     func updateReminder(_ reminder: Reminder)
     func deleteReminder(_ reminder: Reminder)
@@ -17,7 +17,7 @@ protocol ReminderRepositoryDelegate {
 }
 
 /// Realmを用いてReminderのCRUD操作を行う。
-struct ReminderRepository: ReminderRepositoryDelegate {
+struct ReminderRepository: ReminderRepositoryProtocol {
     private let realm: Realm
 
     init() {

--- a/quick-reminder/Model/Repository/UITestMockReminderRepository.swift
+++ b/quick-reminder/Model/Repository/UITestMockReminderRepository.swift
@@ -10,7 +10,7 @@ import Foundation
 /// ReminderRepositoryのモック。UITest用で使用する。
 ///
 /// アプリ起動時に `-useUITestMockRepository` オプションを付加することで使用できる。
-class UITestMockReminderRepository: ReminderRepositoryDelegate {
+class UITestMockReminderRepository: ReminderRepositoryProtocol {
     private var reminders = [Reminder]()
 
     func addReminder(_ reminder: Reminder) {

--- a/quick-reminderTests/Dummy/Repository/MockReminderRepository.swift
+++ b/quick-reminderTests/Dummy/Repository/MockReminderRepository.swift
@@ -8,7 +8,7 @@
 import Foundation
 @testable import quick_reminder
 
-class MockReminderRepository: ReminderRepositoryDelegate {
+class MockReminderRepository: ReminderRepositoryProtocol {
     private(set) var addedReminders: [Reminder] = []
     private(set) var updatedReminders: [Reminder] = []
     private(set) var deletedReminders: [Reminder] = []

--- a/uml/ReminderListVIew.wsd
+++ b/uml/ReminderListVIew.wsd
@@ -10,7 +10,7 @@ namespace ReminderListView.Model #FFFFEC {
     class OldReminderRemoverProtocol <<P, #ffccee)>>
     class OldReminderRemover  <<S, #ffeecc)>> #FFE5FF
     ReminderList "1" o-- "*" Model.Reminder
-    ReminderList *-- Repository.ReminderRepositoryDelegate
+    ReminderList *-- Repository.ReminderRepositoryProtocol
     ReminderList *-- ReminderSorterProtocol
     ReminderList *-- ReminderListValidatorProtocol
     ReminderList .u.|> ReminderListProtocol
@@ -44,7 +44,7 @@ namespace Util #ECEFF4 {
     class DateProviderProtocol <<P, #ffccee)>>
 }
 namespace Repository #ECEFF4 {
-    class ReminderRepositoryDelegate <<P, #ffccee)>>
+    class ReminderRepositoryProtocol <<P, #ffccee)>>
 }
 namespace Model #ECEFF4 {
     class Reminder <<S, #ffeecc)>>

--- a/uml/base.wsd
+++ b/uml/base.wsd
@@ -1,12 +1,12 @@
 @startuml Models
 
 namespace Repository #ECEFF4 {
-    class ReminderRepositoryDelegate <<P, #ffccee)>>
+    class ReminderRepositoryProtocol <<P, #ffccee)>>
     class ReminderRepository  <<S, #ffeecc)>>
     class ReminderDTO
-    ReminderRepository ..|> ReminderRepositoryDelegate
+    ReminderRepository ..|> ReminderRepositoryProtocol
     ReminderRepository --> ReminderDTO: 生成
-    ReminderRepositoryDelegate -r[hidden]-> ReminderDTO
+    ReminderRepositoryProtocol -r[hidden]-> ReminderDTO
     ReminderDTO -d-> Model.Reminder: 　変換　
 }
 


### PR DESCRIPTION
Reminderはdelegateを弱参照に持って何かを委譲しているわけではなく、このprotocolはテストのためにリポジトリを差し替え可能にする目的で使用されているため、Delegateという命名は不適切であった。